### PR TITLE
Possible to exclude datatypes

### DIFF
--- a/App.config
+++ b/App.config
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <appSettings>
+    <add key="excludeDataTypes" value="timestamp;datetimeoffset" />
+  </appSettings>  
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>

--- a/DataScriptWriter.csproj
+++ b/DataScriptWriter.csproj
@@ -76,6 +76,7 @@
       <HintPath>packages\Microsoft.SqlServer.Types.14.0.1016.290\lib\net40\Microsoft.SqlServer.Types.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />


### PR DESCRIPTION
With the key excludeDataTypes in the app.config, it is possible to exclude certain datatypes from being scripted.
For example the datatypes `timestamp` and `datetimeoffset`, which would cause an exception in generating the data-values.

With these settings the Datatable "ColumnInfo" will be filtered in the method `LoadColumnsInfo(ScriptObject so)`

