### PR TITLE
Fix LoadColumnInfo in Resources.resx

### DIFF
--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -163,6 +163,7 @@ LEFT JOIN (
 	select  tc.TABLE_SCHEMA, tc.TABLE_NAME, kcu.COLUMN_NAME, tc.constraint_type 
 	from    information_schema.table_constraints tc 
 	join    information_schema.key_column_usage kcu on 
+			tc.table_schema = kcu.table_schema and 
 			tc.table_name = kcu.table_name and 
 			tc.constraint_name = kcu.constraint_name 
 	where   tc.table_name = parsename(@TableName, 1) and 
@@ -192,6 +193,7 @@ LEFT JOIN (
 	select  tc.TABLE_SCHEMA, tc.TABLE_NAME, kcu.COLUMN_NAME, tc.constraint_type 
 	from    information_schema.table_constraints tc 
 	join    information_schema.key_column_usage kcu on 
+			tc.table_schema = kcu.table_schema and 
 			tc.table_name = kcu.table_name and 
 			tc.constraint_name = kcu.constraint_name 
 	where   tc.table_name = parsename(@TableName, 1) and 


### PR DESCRIPTION
Add table_schema criteria to prevent reading column info from table with same name but different schema.
#23 