### PR TITLE
Allow for sorting by col and row

### DIFF
--- a/App.config
+++ b/App.config
@@ -2,6 +2,8 @@
 <configuration>
   <appSettings>
     <add key="excludeDataTypes" value="timestamp;" />
+    <add key="sortColumnsByOrdinalPosition" value="false" />
+    <add key="sortRowsByPrimaryKey" value="false" />
   </appSettings>  
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>


### PR DESCRIPTION
Nothing changes by default.

If the user configures the app to sort by column, the cols are sorted by their ordinal position in the database table

If the user configures the app to sort by row, the primary keys are discovered and used to sort the main data table

https://github.com/Azure-Player/DataScriptWriter/issues/29